### PR TITLE
upgraded go version

### DIFF
--- a/workflows-sync/pulumi-provider/check-upstream-upgrade.yml
+++ b/workflows-sync/pulumi-provider/check-upstream-upgrade.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           cache-dependency-path: |
             sdk/go.sum
-          go-version: 1.22.x
+          go-version: 1.23.x
 
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/workflows-sync/pulumi-provider/lint.yml
+++ b/workflows-sync/pulumi-provider/lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.23
           cache: false
 
       - name: Disarm go:embed directives to enable lint
@@ -38,7 +38,7 @@ jobs:
         run: make upstream
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.55.2
+          version: v1.64.6
           working-directory: provider


### PR DESCRIPTION
This pull request includes updates to the Go version and the golangci-lint action version in the workflow configuration files. The most important changes are as follows:

Updates to Go version:

* [`workflows-sync/pulumi-provider/check-upstream-upgrade.yml`](diffhunk://#diff-8a6095c89eef62f227443844fcd39e493dc77a29909e877a600dd7616b9bb129L22-R22): Updated the Go version from `1.22.x` to `1.23.x`.
* [`workflows-sync/pulumi-provider/lint.yml`](diffhunk://#diff-1c3d6e839a937cf2b705ccabb3c3b67d1561bef5974d2ca8abfda8664234421cL28-R28): Updated the Go version from `1.22` to `1.23`.

Updates to golangci-lint action version:

* [`workflows-sync/pulumi-provider/lint.yml`](diffhunk://#diff-1c3d6e839a937cf2b705ccabb3c3b67d1561bef5974d2ca8abfda8664234421cL41-R43): Updated the golangci-lint action version from `v4` to `v6` and the golangci-lint version from `v1.55.2` to `v1.64.6`.